### PR TITLE
Fix: Resolve Prisma build error and update build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "npx next dev",
-    "build": "prisma generate --no-engine && npx next build",
+    "build": "node scripts/build.js",
     "start": "npx next start",
     "lint": "npx next lint"
   },

--- a/scripts/setup-prisma.js
+++ b/scripts/setup-prisma.js
@@ -25,8 +25,14 @@ async function setupPrisma() {
     fs.mkdirSync(prismaDir, { recursive: true })
   }
 
+  // Apply database migrations
+  if (!runCommand("npx prisma migrate deploy", "Failed to apply database migrations")) {
+    process.exit(1)
+  }
+
   // Generate Prisma client
-  if (!runCommand("npx prisma generate", "Failed to generate Prisma client")) {
+  // Add --no-engine flag as per plan step 3, will be done in a later step, but good to note here.
+  if (!runCommand("npx prisma generate --no-engine", "Failed to generate Prisma client")) {
     process.exit(1)
   }
 


### PR DESCRIPTION
This commit addresses a build failure caused by Prisma being unable to find tables during the Next.js build process.

The following changes were made:
1. Modified `scripts/setup-prisma.js` to include `npx prisma migrate deploy` before `npx prisma generate`. This ensures that the database schema is synchronized before the Prisma client is generated and the application attempts to query the database.
2. Updated the `build` script in `package.json` to `node scripts/build.js`. This centralizes the build logic and ensures that the `setup-prisma.js` script (with the migration step) is executed.
3. Added the `--no-engine` flag to the `npx prisma generate` command within `scripts/setup-prisma.js`. This follows Prisma's recommendation for production builds, potentially reducing build times and deployment package sizes.

These changes should prevent the "table does not exist" error during the build and ensure a more robust build process.