### PR TITLE
Fix: Resolve media upload and category fetching in post form

### DIFF
--- a/app/admin/posts/new/page.tsx
+++ b/app/admin/posts/new/page.tsx
@@ -1,15 +1,17 @@
 import { PostForm } from "@/components/admin/post-form"
+import prisma from "@/lib/prisma";
 
 export const metadata = {
   title: "New Post - Admin Panel",
   description: "Create a new blog post for your personal website",
 }
 
-export default function NewPostPage() {
+export default async function NewPostPage() {
+  const allCategories = await prisma.category.findMany();
   return (
     <div className="flex flex-col gap-4">
       <h1 className="text-3xl font-bold tracking-tight">New Post</h1>
-      <PostForm />
+      <PostForm categories={allCategories} />
     </div>
   )
 }

--- a/components/admin/post-form.tsx
+++ b/components/admin/post-form.tsx
@@ -63,7 +63,7 @@ export function PostForm({ post = null, categories = [] }) {
     defaultValues: post
       ? {
           ...post,
-          categories: post.categories?.map((cat) => cat._id) || [],
+          categories: post.categories?.map((cat) => cat.id) || [],
           publishedAt: post.publishedAt ? new Date(post.publishedAt).toISOString().split("T")[0] : "",
           content: post.content || "",
         }
@@ -209,7 +209,7 @@ export function PostForm({ post = null, categories = [] }) {
                 <FormItem>
                   <FormLabel>Main Image</FormLabel>
                   <FormControl>
-                    <ImageUpload value={field.value} onChange={field.onChange} />
+                    <ImageUpload key={field.value || 'empty'} value={field.value} onChange={field.onChange} />
                   </FormControl>
                   <FormDescription>
                     This image will be displayed at the top of your post and in listings
@@ -259,7 +259,7 @@ export function PostForm({ post = null, categories = [] }) {
                     <MultiSelect
                       options={categories.map((cat) => ({
                         label: cat.title,
-                        value: cat._id,
+                        value: cat.id,
                       }))}
                       selected={field.value || []}
                       onChange={field.onChange}


### PR DESCRIPTION
This commit addresses two issues in the admin post form:

1.  **Category Fetching for New Posts:**
    - Modified `app/admin/posts/new/page.tsx` to fetch all categories from the database and pass them to the `PostForm` component.
    - Updated `components/admin/post-form.tsx` to correctly use `category.id` (instead of a potential `category._id`) for the `MultiSelect` options and default values, aligning with the Prisma schema. This ensures categories are now available and correctly mapped when you create a new post.

2.  **First Media Upload in PostForm:**
    - Added a `key` prop to the `ImageUpload` component within `components/admin/post-form.tsx` for the `mainImage` field. The key is tied to the `field.value` (image URL).
    - This change forces the `ImageUpload` component to re-mount when its `value` changes (e.g., from empty to an image URL), which can resolve potential state inconsistencies that might have prevented the first uploaded image from displaying correctly.

These changes aim to improve your experience when creating and editing posts by ensuring categories are always available and that media uploads are reliable from the first attempt.