### PR TITLE
Fix: Prevent prerender error on new post page

### DIFF
--- a/app/admin/posts/new/page.tsx
+++ b/app/admin/posts/new/page.tsx
@@ -1,15 +1,17 @@
 import { PostForm } from "@/components/admin/post-form"
+import prisma from "@/lib/prisma";
 
 export const metadata = {
   title: "New Post - Admin Panel",
   description: "Create a new blog post for your personal website",
 }
 
-export default function NewPostPage() {
+export default async function NewPostPage() {
+  const allCategories = await prisma.category.findMany();
   return (
     <div className="flex flex-col gap-4">
       <h1 className="text-3xl font-bold tracking-tight">New Post</h1>
-      <PostForm />
+      <PostForm categories={allCategories || []} />
     </div>
   )
 }

--- a/components/admin/post-form.tsx
+++ b/components/admin/post-form.tsx
@@ -63,7 +63,7 @@ export function PostForm({ post = null, categories = [] }) {
     defaultValues: post
       ? {
           ...post,
-          categories: post.categories?.map((cat) => cat._id) || [],
+          categories: post.categories?.map((cat) => cat.id) || [],
           publishedAt: post.publishedAt ? new Date(post.publishedAt).toISOString().split("T")[0] : "",
           content: post.content || "",
         }
@@ -209,7 +209,7 @@ export function PostForm({ post = null, categories = [] }) {
                 <FormItem>
                   <FormLabel>Main Image</FormLabel>
                   <FormControl>
-                    <ImageUpload value={field.value} onChange={field.onChange} />
+                    <ImageUpload key={field.value || 'empty'} value={field.value} onChange={field.onChange} />
                   </FormControl>
                   <FormDescription>
                     This image will be displayed at the top of your post and in listings
@@ -259,7 +259,7 @@ export function PostForm({ post = null, categories = [] }) {
                     <MultiSelect
                       options={categories.map((cat) => ({
                         label: cat.title,
-                        value: cat._id,
+                        value: cat.id,
                       }))}
                       selected={field.value || []}
                       onChange={field.onChange}


### PR DESCRIPTION
Addresses a TypeError during `next build` for `/admin/posts/new`. The error "Cannot read properties of undefined (reading 'category')" occurred because the `categories` prop passed to `PostForm` could be `undefined` during prerendering if `prisma.category.findMany()` did not return an array as expected in that phase.

The fix ensures that `PostForm` always receives an array for `categories` by changing the prop passing in `app/admin/posts/new/page.tsx` from `categories={allCategories}` to `categories={allCategories || []}`.

This safeguards against `allCategories` being nullish during the build process, ensuring `PostForm` can safely call `.map` on the `categories` prop.