### PR TITLE
Fix: Correct Tiptap SCSS import paths and add missing file

### DIFF
--- a/components/admin/editor.tsx
+++ b/components/admin/editor.tsx
@@ -29,10 +29,10 @@ import {
 
 // --- Tiptap Node ---
 import { ImageUploadNode } from "@/components/tiptap/tiptap-node/image-upload-node/image-upload-node-extension";
-import "@/components/tiptap-node/code-block-node/code-block-node.scss";
-import "@/components/tiptap-node/list-node/list-node.scss";
-import "@/components/tiptap-node/image-node/image-node.scss";
-import "@/components/tiptap-node/paragraph-node/paragraph-node.scss";
+import "@/components/tiptap/tiptap-node/code-block-node/code-block-node.scss";
+import "@/components/tiptap/tiptap-node/list-node/list-node.scss";
+import "@/components/tiptap/tiptap-node/image-node/image-node.scss";
+import "@/components/tiptap/tiptap-node/paragraph-node/paragraph-node.scss";
 
 // --- Tiptap UI ---
 import { HeadingDropdownMenu } from "@/components/tiptap/tiptap-ui/heading-dropdown-menu";
@@ -67,7 +67,7 @@ import { useCursorVisibility } from "@/hooks/tiptap/use-cursor-visibility";
 import { handleImageUpload, MAX_FILE_SIZE } from "@/lib/tiptap-utils";
 
 // --- Styles ---
-import "@/components/tiptap-templates/simple/simple-editor.scss";
+import "@/components/tiptap/tiptap-templates/simple/simple-editor.scss";
 
 const MainToolbarContent = ({
   onHighlighterClick,


### PR DESCRIPTION
This commit addresses Vercel deployment build errors caused by module not found issues for several SCSS files.

The following changes were made:
- I corrected the import paths in `components/admin/editor.tsx` for Tiptap node-specific SCSS files by adding the `tiptap/` directory segment (e.g., `@/components/tiptap/tiptap-node/...`).
- I created an empty `simple-editor.scss` file at `components/tiptap/tiptap-templates/simple/simple-editor.scss` as it was missing from the repository.
- I updated the import path for `simple-editor.scss` in `components/admin/editor.tsx` to reflect its new location.

These changes should allow the Vercel build to complete successfully. You may need to populate the content for the newly added `simple-editor.scss` later.