### PR TITLE
Fix: Correct import path for highlight-popover.scss

### DIFF
--- a/components/tiptap/tiptap-ui/highlight-popover/highlight-popover.tsx
+++ b/components/tiptap/tiptap-ui/highlight-popover/highlight-popover.tsx
@@ -29,7 +29,7 @@ import {
 } from "../highlight-button"
 
 // --- Styles ---
-import "@/components/tiptap-ui/highlight-popover/highlight-popover.scss"
+import "./highlight-popover.scss";
 
 export interface HighlightColor {
   label: string


### PR DESCRIPTION
The import path for highlight-popover.scss in highlight-popover.tsx was incorrect. It was using the "@" alias as if it were the root of the components directory.

This commit changes the import to a relative path, resolving the "Module not found" error.