### PR TITLE
Fix: Ensure text selection is preserved for styling in editor

### DIFF
--- a/components/admin/editor.tsx
+++ b/components/admin/editor.tsx
@@ -212,8 +212,10 @@ export function SimpleEditor({ value, onChange }) {
       Link.configure({ openOnClick: false }),
     ],
     content: value,
-    onUpdate: ({ editor }) => {
-      onChange(editor.getHTML());
+    onTransaction: ({ editor, transaction }) => {
+      if (transaction.docChanged) {
+        onChange(editor.getHTML());
+      }
     },
   });
 


### PR DESCRIPTION
Changed the Tiptap editor's update handling from `onUpdate` to `onTransaction`. The `onChange` callback is now only triggered if `transaction.docChanged` is true. This prevents interference with the selection state when applying styles (e.g., bold, italic) to specific parts of the text, while still ensuring that overall content changes are correctly propagated.