### PR TITLE
Fix: Enable scrolling on new blog post page

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -24,7 +24,7 @@ export default async function AdminLayout({
     <div className="grid min-h-screen w-full md:grid-cols-[240px_1fr] lg:grid-cols-[280px_1fr]">
       <AdminSidebar />
       <div className="flex flex-col">
-        <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
+        <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8 overflow-y-auto">
           <div className="mx-auto w-full max-w-6xl">{children}</div>
         </main>
       </div>


### PR DESCRIPTION
Added `overflow-y-auto` to the main content area in the admin layout to allow scrolling when content exceeds the viewport height.